### PR TITLE
Case insensitive group matching in middleware

### DIFF
--- a/src/Http/Middleware/LdapMiddleware.php
+++ b/src/Http/Middleware/LdapMiddleware.php
@@ -61,7 +61,13 @@ class LdapMiddleware
     protected function ldapUserDisallowed()
     {
         return with(config('laravel_ldap.allowed_groups'), function ($allowedGroups) {
-            return array_intersect($allowedGroups, $this->ldapUser->memberof) !== $allowedGroups;
+            $allowedGroups = array_map(function ($group) {
+                return mb_strtoupper($allowedGroups);
+            }, $allowedGroups);
+
+            return array_intersect($allowedGroups, array_map(function ($group) {
+                return mb_strtoupper($group);
+            }, $this->ldapUser->memberof)) !== $allowedGroups;
         });
     }
 

--- a/src/Http/Middleware/LdapMiddleware.php
+++ b/src/Http/Middleware/LdapMiddleware.php
@@ -62,7 +62,7 @@ class LdapMiddleware
     {
         return with(config('laravel_ldap.allowed_groups'), function ($allowedGroups) {
             $allowedGroups = array_map(function ($group) {
-                return mb_strtoupper($allowedGroups);
+                return mb_strtoupper($group);
             }, $allowedGroups);
 
             return array_intersect($allowedGroups, array_map(function ($group) {


### PR DESCRIPTION
Convert each of the allowed groups to uppercase and compare against uppercase versions of the authenticated users membership groups.

This should help to account for discrepancies in case between the strings entered in `laravel_ldap.allowed_groups` and what the LDAP server returns.

It _appears_ as though `adldap2` does this matching in a case-insensitive manner, as changing the case in strings for testing continues to authenticate successfully.