### PR TITLE
Use Str class over global helper

### DIFF
--- a/src/Http/Middleware/LdapMiddleware.php
+++ b/src/Http/Middleware/LdapMiddleware.php
@@ -4,6 +4,7 @@ namespace Dyrynda\Ldap\Http\Middleware;
 
 use Adldap;
 use Closure;
+use Illuminate\Support\Str;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\MessageBag;
 
@@ -129,7 +130,7 @@ class LdapMiddleware
      */
     protected function cacheKey($request)
     {
-        return sprintf('ldapUser.%s', str_slug($this->identifier($request)));
+        return sprintf('ldapUser.%s', Str::slug($this->identifier($request)));
     }
 
     /**


### PR DESCRIPTION
`str_slug` was removed from the global helpers in version 6 and is now a optional package.

This uses the Str class instead. 